### PR TITLE
Improve get_jwt to better handle multiple optional params

### DIFF
--- a/src/shipchain_common/test_utils.py
+++ b/src/shipchain_common/test_utils.py
@@ -46,16 +46,16 @@ def datetimeAlmostEqual(dt1, dt2=None, ms_threshold=None):
     return dt1 - timedelta(milliseconds=ms_threshold) <= dt2 <= dt1 + timedelta(milliseconds=ms_threshold)
 
 
-def get_jwt(exp=None, sub='00000000-0000-0000-0000-000000000000', username='fake@shipchain.io',
-            organization_id=None, monthly_rate_limit=None):
+def get_jwt(exp=None, sub='00000000-0000-0000-0000-000000000000', username='fake@shipchain.io', **kwargs):
     payload = {'email': username, 'username': username, 'sub': sub,
                'aud': '892633'}
 
-    if organization_id:
-        payload['organization_id'] = organization_id
-
-    if monthly_rate_limit:
-        payload['monthly_rate_limit'] = monthly_rate_limit
+    for prop_name, prop_value in kwargs.items():
+        if prop_value is not None:
+            # we test 'prop_value' against None to avoid being caught
+            # with a boolean 'prop_value = False' which will be false
+            # but needs to be set
+            payload[prop_name] = prop_value
 
     now = aware_utcnow()
     if exp:


### PR DESCRIPTION
With this change, we make sure that additional `optional` parameters can be properly passed to the `get_jwt` method and set in the payload.