### PR TITLE
Allow Engine RPC request timeout to be configurable

### DIFF
--- a/src/shipchain_common/rpc.py
+++ b/src/shipchain_common/rpc.py
@@ -46,7 +46,9 @@ class RPCClient:
         try:
             with TimingMetric('engine_rpc.call', tags={'method': method}) as timer:
                 response_json = settings.REQUESTS_SESSION.post(self.url,
-                                                               data=json.dumps(self.payload, cls=DecimalEncoder)).json()
+                                                               data=json.dumps(self.payload, cls=DecimalEncoder),
+                                                               timeout=getattr(settings, 'REQUESTS_TIMEOUT', 4.5)
+                                                               ).json()
                 LOG.info('rpc_client(%s) duration: %.3f', method, timer.elapsed)
 
             if 'error' in response_json:

--- a/src/shipchain_common/rpc.py
+++ b/src/shipchain_common/rpc.py
@@ -47,7 +47,7 @@ class RPCClient:
             with TimingMetric('engine_rpc.call', tags={'method': method}) as timer:
                 response_json = settings.REQUESTS_SESSION.post(self.url,
                                                                data=json.dumps(self.payload, cls=DecimalEncoder),
-                                                               timeout=getattr(settings, 'REQUESTS_TIMEOUT', 4.5)
+                                                               timeout=getattr(settings, 'REQUESTS_TIMEOUT', 270)
                                                                ).json()
                 LOG.info('rpc_client(%s) duration: %.3f', method, timer.elapsed)
 


### PR DESCRIPTION
Allow Engine RPC request timeout to be configurable via a REQUESTS_TIMEOUT setting, default to 4.5m