### PR TITLE
Use relative import in middleware module

### DIFF
--- a/src/shipchain_common/custom_logging/middleware.py
+++ b/src/shipchain_common/custom_logging/middleware.py
@@ -27,7 +27,7 @@ class UserOrganizationMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         # We put this import here to avoid cyclical imports during app init
-        from src.shipchain_common.authentication import PASSIVE_JWT_AUTHENTICATION, passive_credentials_auth
+        from ..authentication import PASSIVE_JWT_AUTHENTICATION, passive_credentials_auth
 
         user_id, org_id = None, None
         header = PASSIVE_JWT_AUTHENTICATION.get_header(request)


### PR DESCRIPTION
This change uses relative module import in `custom_logging.middleware` to avoid import error once package is published.