### PR TITLE
Enhanced JSON renderer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shipchain-common"
-version = "1.0.9"
+version = "1.0.10"
 description = "A PyPI package containing shared code for ShipChain's Python/Django projects."
 
 license = "Apache-2.0"

--- a/src/shipchain_common/renderers.py
+++ b/src/shipchain_common/renderers.py
@@ -8,6 +8,9 @@ def _get_resource_name(context, expand_polymorphic_types=False):
     """
     Return the name of a resource with a special override for ConfigurableGenericViewSet's multiple serializers
     """
+    if CGVSJsonRenderer.original_get_resource_name is None:
+        raise Exception('original_get_resource_name was not captured')
+
     view = context.get('view')
     is_response = context.get('response', False)
 
@@ -28,6 +31,7 @@ def _get_resource_name(context, expand_polymorphic_types=False):
 
         # Force the default method to find our serializer at view.resource_name and reset when we're done
         setattr(view, 'resource_name', resource_name)
+        # pylint: disable=not-callable
         resource_name = CGVSJsonRenderer.original_get_resource_name(context, expand_polymorphic_types)
         setattr(view, 'resource_name', original_view_resource_name)
 
@@ -35,6 +39,7 @@ def _get_resource_name(context, expand_polymorphic_types=False):
 
     # For any exceptions above, fallback to original method
     except AttributeError:
+        # pylint: disable=not-callable
         return CGVSJsonRenderer.original_get_resource_name(context, expand_polymorphic_types)
 
 

--- a/src/shipchain_common/renderers.py
+++ b/src/shipchain_common/renderers.py
@@ -1,0 +1,49 @@
+from rest_framework_json_api import renderers, utils
+from rest_framework_json_api.serializers import PolymorphicModelSerializer
+
+from .mixins import SerializationType
+
+
+def _get_resource_name(context, expand_polymorphic_types=False):
+    """
+    Return the name of a resource with a special override for ConfigurableGenericViewSet's multiple serializers
+    """
+    view = context.get('view')
+    is_response = context.get('response', False)
+
+    try:
+        original_view_resource_name = getattr(view, 'resource_name', None)
+
+        # If view.resource_name was set, respect it
+        if original_view_resource_name:
+            raise AttributeError
+
+        serializer = view.get_serializer_class(
+            serialization_type=SerializationType.RESPONSE if is_response else SerializationType.REQUEST)
+
+        if expand_polymorphic_types and issubclass(serializer, PolymorphicModelSerializer):
+            resource_name = serializer.get_polymorphic_types()
+        else:
+            resource_name = utils.get_resource_type_from_serializer(serializer)
+
+        # Force the default method to find our serializer at view.resource_name and reset when we're done
+        setattr(view, 'resource_name', resource_name)
+        resource_name = CGVSJsonRenderer.original_get_resource_name(context, expand_polymorphic_types)
+        setattr(view, 'resource_name', original_view_resource_name)
+
+        return resource_name
+
+    # For any exceptions above, fallback to original method
+    except AttributeError:
+        return CGVSJsonRenderer.original_get_resource_name(context, expand_polymorphic_types)
+
+
+class CGVSJsonRenderer(renderers.JSONRenderer):
+    """JSONRenderer that is aware of the multiple serializers in ConfigurableGenericViewSet
+    This also affects the JSONParser since we are patching method in the util package
+    """
+    original_get_resource_name = None
+
+    if original_get_resource_name is None:
+        original_get_resource_name = utils.get_resource_name
+        utils.get_resource_name = _get_resource_name

--- a/tests/django_mocking/models.py
+++ b/tests/django_mocking/models.py
@@ -1,5 +1,6 @@
 from enumfields import Enum, EnumIntegerField
-from django.db.models import Model
+from django.db import models
+from shipchain_common import utils
 
 
 class GenericEnum(Enum):
@@ -13,5 +14,10 @@ class GenericEnum(Enum):
         THIRD = 'THIRD'
 
 
-class EnumObject(Model):
+class EnumObject(models.Model):
     enum_field = EnumIntegerField(enum=GenericEnum, default=GenericEnum.FIRST)
+
+
+class BasicModel(models.Model):
+    id = models.CharField(primary_key=True, max_length=36, default=utils.random_id)
+    my_field = models.CharField(max_length=1)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,0 +1,116 @@
+import json
+
+import django
+# We run django.setup() in order to auto populate the base django's app models for testing purposes
+import pytest
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework_json_api import serializers
+
+from tests.django_mocking.models import BasicModel
+
+try:
+    django.setup()
+except Exception as exc:
+    raise exc
+
+from shipchain_common.viewsets import ActionConfiguration, ConfigurableGenericViewSet
+from shipchain_common.renderers import CGVSJsonRenderer
+
+
+class DefaultSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = BasicModel
+        fields = '__all__'
+
+    class JSONAPIMeta:
+        resource_name = 'DefaultSerializer'
+
+
+class ListResponseSerializer(DefaultSerializer):
+    class JSONAPIMeta:
+        resource_name = 'ListResponseSerializer'
+
+
+class CreateRequestSerializer(DefaultSerializer):
+    class JSONAPIMeta:
+        resource_name = 'CreateRequestSerializer'
+
+
+class CreateResponseSerializer(DefaultSerializer):
+    class JSONAPIMeta:
+        resource_name = 'CreateResponseSerializer'
+
+
+class CustomActionSerializer(DefaultSerializer):
+    class JSONAPIMeta:
+        resource_name = 'CustomActionSerializer'
+
+
+class CustomActionCSVSerializer(DefaultSerializer):
+    class JSONAPIMeta:
+        resource_name = 'CustomActionCSVSerializer'
+
+
+class TestCGVSJsonRenderer:
+
+    @pytest.fixture
+    def viewset(self):
+        class TestViewSet(ConfigurableGenericViewSet):
+            kwargs = {}
+            request = {}
+            response = Response(status=status.HTTP_200_OK)
+            format_kwarg = ''
+            serializer_class = DefaultSerializer
+
+        return TestViewSet()
+
+    def test_get_resource_from_configurable_serializer(self, viewset):
+        viewset.configuration = {
+            'list': ActionConfiguration(
+                response_serializer=ListResponseSerializer,
+            ),
+            'create': ActionConfiguration(
+                request_serializer=CreateRequestSerializer,
+                response_serializer=CreateResponseSerializer,
+            ),
+            'custom_action': ActionConfiguration(
+                request_serializer=CustomActionSerializer,
+                response_serializer={
+                    'default': CustomActionSerializer,
+                    'csv': CustomActionCSVSerializer,
+                },
+            ),
+        }
+
+        renderer = CGVSJsonRenderer()
+        response_data = DefaultSerializer(BasicModel(my_field='1')).data
+        renderer_context = {'view': viewset, 'request': viewset.request, 'response': viewset.response}
+
+        viewset.action = 'update'
+        response = renderer.render(response_data, renderer_context=renderer_context)
+        response = json.loads(response)
+        assert response['data']['type'] == 'DefaultSerializer'
+
+        viewset.action = 'list'
+        response = renderer.render(response_data, renderer_context=renderer_context)
+        response = json.loads(response)
+        assert response['data']['type'] == 'ListResponseSerializer'
+
+        viewset.action = 'create'
+        response = renderer.render(response_data, renderer_context=renderer_context)
+        response = json.loads(response)
+        assert response['data']['type'] == 'CreateResponseSerializer'
+
+        viewset.action = 'custom_action'
+        response = renderer.render(response_data, renderer_context=renderer_context)
+        response = json.loads(response)
+        assert response['data']['type'] == 'CustomActionSerializer'
+
+        viewset.action = 'custom_action'
+        viewset.kwargs['format'] = 'csv'
+        response = renderer.render(response_data, renderer_context=renderer_context)
+        response = json.loads(response)
+        assert response['data']['type'] == 'CustomActionCSVSerializer'
+        viewset.kwargs['format'] = None


### PR DESCRIPTION
The default renderers in Django Rest Framework and DRF JSON API do not know how to handle the multiple serializers supported by a `ConfigurableGenericViewSet`.  This causes the resource type in responses from the API to be incorrect in some situations where the default, request, and response serializers use different resources.

The `CGVSJsonRenderer` resolves this by providing the `serialization_type` parameter to the `ConfigurableGenericViewSet.get_serializer_class()` method indicating the response serializer is desired.