### PR TITLE
Bug fix jsonApi page size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shipchain-common"
-version = "1.0.12"
+version = "1.0.13"
 description = "A PyPI package containing shared code for ShipChain's Python/Django projects."
 
 license = "Apache-2.0"

--- a/src/shipchain_common/pagination.py
+++ b/src/shipchain_common/pagination.py
@@ -23,6 +23,7 @@ class JsonApiPagePagination(JsonApiPageNumberPagination):
     with page query param: 'page[number]' that needs to be overridden here with proper value
     """
     page_query_param = 'page'
+    page_size_query_param = 'page_size'
 
 
 class CustomResponsePagination(JsonApiPagePagination):


### PR DESCRIPTION
With the upgrade to `djangorestframework-jsonapi~3.0` the page size query parameter attribute name has changed to `page[size]` instead of `page_size`. This branch fixes this issue by overriding the attribute `JsonApiPagePagination.page_size_query_param` to its previous value.