### PR TITLE
Add pointer check for HTTP 400 and 404

### DIFF
--- a/src/shipchain_common/test_utils/json_asserter.py
+++ b/src/shipchain_common/test_utils/json_asserter.py
@@ -343,6 +343,18 @@ def assert_404(response, error='Not found', pointer=None):
     response_has_error(response, error, pointer)
 
 
+def assert_500(response, error='A server error occurred.', pointer=None):
+    assert response is not None
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, f'status_code {response.status_code} != 500'
+    response_has_error(response, error, pointer)
+
+
+def assert_503(response, error='Service temporarily unavailable, try again later', pointer=None):
+    assert response is not None
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE, f'status_code {response.status_code} != 503'
+    response_has_error(response, error, pointer)
+
+
 class AssertionHelper:
     EntityRef = EntityReferenceClass
 
@@ -355,6 +367,9 @@ class AssertionHelper:
     HTTP_401 = assert_401
     HTTP_403 = assert_403
     HTTP_404 = assert_404
+
+    HTTP_500 = assert_500
+    HTTP_503 = assert_503
 
 
 @pytest.fixture(scope='session')

--- a/src/shipchain_common/test_utils/json_asserter.py
+++ b/src/shipchain_common/test_utils/json_asserter.py
@@ -299,6 +299,21 @@ def assert_201(response, vnd=True, entity_refs=None, included=None, is_list=Fals
                       entity_refs=entity_refs)
 
 
+def assert_202(response, vnd=True, entity_refs=None, included=None, is_list=False,
+               resource=None, pk=None, attributes=None, relationships=None):
+    assert response is not None
+    assert response.status_code == status.HTTP_202_ACCEPTED, f'status_code {response.status_code} != 202'
+    response_has_data(response,
+                      attributes=attributes,
+                      relationships=relationships,
+                      included=included,
+                      is_list=is_list,
+                      vnd=vnd,
+                      resource=resource,
+                      pk=pk,
+                      entity_refs=entity_refs)
+
+
 def assert_204(response):
     assert response is not None
     assert response.status_code == status.HTTP_204_NO_CONTENT, f'status_code {response.status_code} != 204'
@@ -333,6 +348,7 @@ class AssertionHelper:
 
     HTTP_200 = assert_200
     HTTP_201 = assert_201
+    HTTP_202 = assert_202
     HTTP_204 = assert_204
 
     HTTP_400 = assert_400

--- a/src/shipchain_common/test_utils/json_asserter.py
+++ b/src/shipchain_common/test_utils/json_asserter.py
@@ -33,7 +33,7 @@ class EntityReferenceClass:
                f'attributes: {self.attributes}; relationships: {self.relationships}'
 
 
-def response_has_error(response, error):
+def response_has_error(response, error, pointer=None):
     if error is not None:
         response_json = response.json()
         assert 'errors' in response_json, f'Malformed error response: {response_json}'
@@ -44,6 +44,9 @@ def response_has_error(response, error):
         for single_error in response_json['errors']:
             if error in single_error['detail']:
                 error_found = True
+                if pointer:
+                    found_pointer = single_error['source']['pointer']
+                    assert pointer in found_pointer, f'Error `{pointer}` not found in {found_pointer}'
 
         if not error_found:
             assert False, f'Error `{error}` not found in {response_json}'
@@ -301,10 +304,10 @@ def assert_204(response):
     assert response.status_code == status.HTTP_204_NO_CONTENT, f'status_code {response.status_code} != 204'
 
 
-def assert_400(response, error=None):
+def assert_400(response, error=None, pointer=None):
     assert response is not None
     assert response.status_code == status.HTTP_400_BAD_REQUEST, f'status_code {response.status_code} != 400'
-    response_has_error(response, error)
+    response_has_error(response, error, pointer)
 
 
 def assert_401(response, error='Authentication credentials were not provided'):
@@ -319,10 +322,10 @@ def assert_403(response, error='You do not have permission to perform this actio
     response_has_error(response, error)
 
 
-def assert_404(response, error='Not found'):
+def assert_404(response, error='Not found', pointer=None):
     assert response is not None
     assert response.status_code == status.HTTP_404_NOT_FOUND, f'status_code {response.status_code} != 404'
-    response_has_error(response, error)
+    response_has_error(response, error, pointer)
 
 
 class AssertionHelper:

--- a/tests/test_json_asserter.py
+++ b/tests/test_json_asserter.py
@@ -241,6 +241,15 @@ class TestAssertionHelper:
             json_asserter.HTTP_201(response)
         assert 'status_code 400 != 201' in str(err.value)
 
+    def test_status_202(self, json_asserter, vnd_single, vnd_error_400):
+        response = self.build_response(vnd_single, status_code=status.HTTP_202_ACCEPTED)
+        json_asserter.HTTP_202(response)
+
+        with pytest.raises(AssertionError) as err:
+            response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
+            json_asserter.HTTP_202(response)
+        assert 'status_code 400 != 202' in str(err.value)
+
     def test_status_204(self, json_asserter, vnd_single, vnd_error_400):
         response = self.build_response(vnd_single, status_code=status.HTTP_204_NO_CONTENT)
         json_asserter.HTTP_204(response)
@@ -296,6 +305,36 @@ class TestAssertionHelper:
             response = self.build_response(vnd_single)
             json_asserter.HTTP_404(response)
         assert 'status_code 200 != 404' in str(err.value)
+
+    def test_status_500(self, json_asserter, vnd_single, vnd_error):
+        vnd_error['errors'][0]['detail'] = 'A server error occurred.'
+        response = self.build_response(vnd_error, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        json_asserter.HTTP_500(response)
+
+        with pytest.raises(AssertionError) as err:
+            response = self.build_response(vnd_single)
+            json_asserter.HTTP_500(response)
+        assert 'status_code 200 != 500' in str(err.value)
+
+    def test_status_500_custom_message(self, json_asserter, vnd_error):
+        vnd_error['errors'][0]['detail'] = 'custom error message'
+        response = self.build_response(vnd_error, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        json_asserter.HTTP_500(response, error='custom error message')
+
+    def test_status_503(self, json_asserter, vnd_single, vnd_error):
+        vnd_error['errors'][0]['detail'] = 'Service temporarily unavailable, try again later'
+        response = self.build_response(vnd_error, status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+        json_asserter.HTTP_503(response)
+
+        with pytest.raises(AssertionError) as err:
+            response = self.build_response(vnd_single)
+            json_asserter.HTTP_503(response)
+        assert 'status_code 200 != 503' in str(err.value)
+
+    def test_status_503_custom_message(self, json_asserter, vnd_error):
+        vnd_error['errors'][0]['detail'] = 'custom error message'
+        response = self.build_response(vnd_error, status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+        json_asserter.HTTP_503(response, error='custom error message')
 
     def test_status_wrong_message(self, json_asserter, vnd_error_404):
         response = self.build_response(vnd_error_404, status_code=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
This feature allows for the addition of a "pointer" when asserting 400 and 404 errors. This allows you to ensure that the error message that occurred was created by a specific feature. 