### PR TITLE
Add INT to internal requests permissions for Integration testing

### DIFF
--- a/src/shipchain_common/authentication.py
+++ b/src/shipchain_common/authentication.py
@@ -50,7 +50,7 @@ def is_internal_call(request):
 
 class InternalRequest(BasePermission):
     def has_permission(self, request, view):
-        if settings.ENVIRONMENT in ('LOCAL',):
+        if settings.ENVIRONMENT in ('LOCAL', 'INT'):
             return True
         if is_internal_call(request):
             certificate_cn = parse_dn(request.META['X_SSL_CLIENT_DN'])['CN']


### PR DESCRIPTION
This fixes an issue with the Transmission integration tests, where shipments were unable to be created on engine as it didn't have the correct permissions to call the events endpoint.