### PR TITLE
Create JsonAPIClient

### DIFF
--- a/src/shipchain_common/test_utils/__init__.py
+++ b/src/shipchain_common/test_utils/__init__.py
@@ -28,7 +28,8 @@ from .helpers import\
     random_location,\
     random_timestamp, \
     replace_variables_in_string, \
-    GeoCoderResponse
+    GeoCoderResponse, \
+    JsonAPIClient
 
 from .mocked_rpc_responses import \
     mocked_rpc_response, \

--- a/src/shipchain_common/test_utils/helpers.py
+++ b/src/shipchain_common/test_utils/helpers.py
@@ -24,6 +24,7 @@ import jwt
 from django.conf import settings
 from django.test.client import encode_multipart
 from rest_framework_simplejwt.utils import aware_utcnow, datetime_to_epoch
+from rest_framework.test import APIClient
 
 
 def create_form_content(data):
@@ -131,3 +132,17 @@ class GeoCoderResponse:
     def __init__(self, status, point=None):
         self.ok = status
         self.xy = point
+
+# pylint: disable=too-many-arguments, redefined-builtin
+class JsonAPIClient(APIClient):
+    def post(self, path, data=None, format='json', content_type=None, follow=False, **extra):
+        return super().post(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+
+    def put(self, path, data=None, format='json', content_type=None, follow=False, **extra):
+        return super().put(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+
+    def patch(self, path, data=None, format='json', content_type=None, follow=False, **extra):
+        return super().patch(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+
+    def delete(self, path, data=None, format='json', content_type=None, follow=False, **extra):
+        return super().delete(path, data=data, format=format, content_type=content_type, follow=follow, **extra)

--- a/src/shipchain_common/test_utils/helpers.py
+++ b/src/shipchain_common/test_utils/helpers.py
@@ -133,6 +133,7 @@ class GeoCoderResponse:
         self.ok = status
         self.xy = point
 
+
 # pylint: disable=too-many-arguments, redefined-builtin
 class JsonAPIClient(APIClient):
     def post(self, path, data=None, format='json', content_type=None, follow=False, **extra):


### PR DESCRIPTION
This client is useful when running tests, as it defaults the format to `json`, as is desired in most of our test cases. This was already being used by profiles, however since it would be useful in transmission also it was moved to python-common.