### PR TITLE
Add count and ordering to json_asserter and non-vnd error reports

### DIFF
--- a/src/shipchain_common/test_utils/json_asserter.py
+++ b/src/shipchain_common/test_utils/json_asserter.py
@@ -52,6 +52,15 @@ def response_has_error(response, error, pointer=None):
             assert False, f'Error `{error}` not found in {response_json}'
 
 
+def response_has_json_error(response, error):
+    if error is not None:
+        response_json = response.json()
+        assert 'detail' in response_json, f'Malformed error response: {response_json}'
+        assert isinstance(response_json, dict), f'Error response not a dict: {response_json}'
+
+        assert response_json['detail'] == error, f'Error {error} not found in {response_json["detail"]}'
+
+
 def _vnd_assert_attributes(response_data, attributes):
     """
     Scan response data for all attributes
@@ -198,78 +207,114 @@ def _plain_assert_attributes_in_list(response_list, attributes):
     assert found_include, f'{attributes} NOT IN  {response_list}'
 
 
-def response_has_data(response, vnd=True, entity_refs=None, included=None, is_list=False,
-                      resource=None, pk=None, attributes=None, relationships=None):
+def _test_vnd_json(response, entity_refs=None, included=None, is_list=False, count=None, resource=None, pk=None,
+                   attributes=None, relationships=None, check_ordering=False):
+    assert 'data' in response, f'response does not contain `data` property: {response}'
+
+    # if (attributes or relationships or resource or pk) and entity_refs:
+    assert not ((attributes or relationships or resource or pk) and entity_refs), \
+        'Use Only `entity_refs` or explicit `attributes`, `relationships`, `resource`, and `pk` but not both'
+
+    if (attributes or relationships or resource or pk) and not entity_refs:
+        entity_refs = EntityReferenceClass(resource=resource,
+                                           pk=pk,
+                                           attributes=attributes,
+                                           relationships=relationships)
+
+    response_data = response['data']
+
+    if is_list:
+        assert isinstance(response_data, list), f'Response should be a list'
+
+        # Included resources are outside of the list response
+        if included:
+            _vnd_assert_include(response, included)
+
+        # Assertion for only included and not entities is valid
+        if entity_refs:
+            if not isinstance(entity_refs, list):
+                entity_refs = [entity_refs]
+
+            if not check_ordering:
+                for entity_ref in entity_refs:
+                    _vnd_assert_entity_ref_in_list(response_data, entity_ref)
+            else:
+                assert len(entity_refs) <= len(response_data), \
+                    f'Error: more entity refs supplied than available in response data. ' \
+                    f'{len(response_data)} found asserted {len(entity_refs)}'
+                for iteration, entity_ref in enumerate(entity_refs):
+                    _vnd_assertions(response_data[iteration], entity_ref)
+
+        if not (count is None):
+            assert len(response_data) == count, \
+                f'Difference in count of response_data, got {len(response_data)} expected {count}'
+
+    else:
+        assert not isinstance(response_data, list), f'Response should not be a list'
+        assert not (entity_refs and isinstance(entity_refs, list)), \
+            f'entity_refs should not be a list for a non-list response'
+
+        assert (count is None), 'Count is only checked when response is list'
+        assert not check_ordering, 'Ordering is only checked when response is list'
+
+        # Included resources are outside of the list response
+        if included:
+            _vnd_assert_include(response, included)
+
+        # Assertion for only status is valid
+        if entity_refs:
+            _vnd_assertions(response_data, entity_refs)
+
+
+def _test_regular_json(response, entity_refs=None, included=None, is_list=False, count=None, attributes=None,
+                       relationships=None, check_ordering=False):
+    assert not relationships, f'relationships not valid when vnd=False'
+    assert not entity_refs, f'entity_refs not valid when vnd=False'
+    assert not included, f'included not valid when vnd=False'
+    assert attributes, f'attributes must be provided when vnd=False'
+
+    if is_list:
+        assert isinstance(response, list), f'Response should be a list'
+
+        if not isinstance(attributes, list):
+            attributes = [attributes]
+
+        if not check_ordering:
+            for attribute in attributes:
+                _plain_assert_attributes_in_list(response, attribute)
+
+        else:
+            assert len(attributes) <= len(response), \
+                f'Error: more attributes supplied than available in response. ' \
+                f'{len(attributes)} found asserted {len(response)}'
+            for iteration, attribute in enumerate(attributes):
+                _plain_assert_attributes_in_response(response[iteration], attribute)
+        if not (count is None):
+            assert len(response) == count,\
+                f'Difference in count of response_data, got {len(response)} expected {count}'
+    else:
+        assert not isinstance(response, list), f'Response should not be a list'
+        assert not (attributes and isinstance(attributes, list)), \
+            f'attributes should not be a list for a non-list response'
+
+        _plain_assert_attributes_in_response(response, attributes)
+
+
+def response_has_data(response, vnd=True, entity_refs=None, included=None, is_list=False, count=None,
+                      resource=None, pk=None, attributes=None, relationships=None, check_ordering=False):
     response = response.json()
 
     # application/vnd.api+json
     if vnd:
-        assert 'data' in response, f'response does not contain `data` property: {response}'
-
-        # if (attributes or relationships or resource or pk) and entity_refs:
-        assert not ((attributes or relationships or resource or pk) and entity_refs), \
-            'Use Only `entity_refs` or explicit `attributes`, `relationships`, `resource`, and `pk` but not both'
-
-        if (attributes or relationships or resource or pk) and not entity_refs:
-            entity_refs = EntityReferenceClass(resource=resource,
-                                               pk=pk,
-                                               attributes=attributes,
-                                               relationships=relationships)
-
-        response_data = response['data']
-
-        if is_list:
-            assert isinstance(response_data, list), f'Response should be a list'
-
-            # Included resources are outside of the list response
-            if included:
-                _vnd_assert_include(response, included)
-
-            # Assertion for only included and not entities is valid
-            if entity_refs:
-                if not isinstance(entity_refs, list):
-                    entity_refs = [entity_refs]
-
-                for entity_ref in entity_refs:
-                    _vnd_assert_entity_ref_in_list(response_data, entity_ref)
-
-        else:
-            assert not isinstance(response_data, list), f'Response should not be a list'
-            assert not (entity_refs and isinstance(entity_refs, list)), \
-                f'entity_refs should not be a list for a non-list response'
-
-            # Included resources are outside of the list response
-            if included:
-                _vnd_assert_include(response, included)
-
-            # Assertion for only status is valid
-            if entity_refs:
-                _vnd_assertions(response_data, entity_refs)
+        _test_vnd_json(response, entity_refs, included, is_list, count, resource, pk, attributes, relationships,
+                       check_ordering)
 
     # application/json
     else:
-        assert not relationships, f'relationships not valid when vnd=False'
-        assert not entity_refs, f'entity_refs not valid when vnd=False'
-        assert not included, f'included not valid when vnd=False'
-        assert attributes, f'attributes must be provided when vnd=False'
-
-        if is_list:
-            assert isinstance(response, list), f'Response should be a list'
-
-            if not isinstance(attributes, list):
-                attributes = [attributes]
-
-            for attribute in attributes:
-                _plain_assert_attributes_in_list(response, attribute)
-        else:
-            assert not isinstance(response, list), f'Response should not be a list'
-            assert not (attributes and isinstance(attributes, list)), \
-                f'attributes should not be a list for a non-list response'
-
-            _plain_assert_attributes_in_response(response, attributes)
+        _test_regular_json(response, entity_refs, included, is_list, count, attributes, relationships, check_ordering)
 
 
-def assert_200(response, vnd=True, entity_refs=None, included=None, is_list=False,
+def assert_200(response, vnd=True, entity_refs=None, included=None, is_list=False, count=None, check_ordering=False,
                resource=None, pk=None, attributes=None, relationships=None):
     assert response is not None
     assert response.status_code == status.HTTP_200_OK, f'status_code {response.status_code} != 200'
@@ -281,7 +326,9 @@ def assert_200(response, vnd=True, entity_refs=None, included=None, is_list=Fals
                       vnd=vnd,
                       resource=resource,
                       pk=pk,
-                      entity_refs=entity_refs)
+                      entity_refs=entity_refs,
+                      count=count,
+                      check_ordering=check_ordering)
 
 
 def assert_201(response, vnd=True, entity_refs=None, included=None, is_list=False,
@@ -319,28 +366,49 @@ def assert_204(response):
     assert response.status_code == status.HTTP_204_NO_CONTENT, f'status_code {response.status_code} != 204'
 
 
-def assert_400(response, error=None, pointer=None):
+def assert_400(response, error=None, pointer=None, vnd=True):
     assert response is not None
     assert response.status_code == status.HTTP_400_BAD_REQUEST, f'status_code {response.status_code} != 400'
-    response_has_error(response, error, pointer)
+    if vnd:
+        response_has_error(response, error, pointer)
+    else:
+        response_has_json_error(response, error)
 
 
-def assert_401(response, error='Authentication credentials were not provided'):
+def assert_401(response, error='Authentication credentials were not provided', vnd=True):
     assert response is not None
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, f'status_code {response.status_code} != 401'
-    response_has_error(response, error)
+    if vnd:
+        response_has_error(response, error)
+    else:
+        response_has_json_error(response, error)
 
 
-def assert_403(response, error='You do not have permission to perform this action'):
+def assert_403(response, error='You do not have permission to perform this action', vnd=True):
     assert response is not None
     assert response.status_code == status.HTTP_403_FORBIDDEN, f'status_code {response.status_code} != 403'
-    response_has_error(response, error)
+    if vnd:
+        response_has_error(response, error)
+    else:
+        response_has_json_error(response, error)
 
 
-def assert_404(response, error='Not found', pointer=None):
+def assert_404(response, error='Not found', pointer=None, vnd=True):
     assert response is not None
     assert response.status_code == status.HTTP_404_NOT_FOUND, f'status_code {response.status_code} != 404'
-    response_has_error(response, error, pointer)
+    if vnd:
+        response_has_error(response, error, pointer)
+    else:
+        response_has_json_error(response, error)
+
+
+def assert_405(response, error='Method not allowed', pointer=None, vnd=True):
+    assert response is not None
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED, f'status_code {response.status_code} != 405'
+    if vnd:
+        response_has_error(response, error, pointer)
+    else:
+        response_has_json_error(response, error)
 
 
 def assert_500(response, error='A server error occurred.', pointer=None):
@@ -367,6 +435,7 @@ class AssertionHelper:
     HTTP_401 = assert_401
     HTTP_403 = assert_403
     HTTP_404 = assert_404
+    HTTP_405 = assert_405
 
     HTTP_500 = assert_500
     HTTP_503 = assert_503


### PR DESCRIPTION
This adds two features the json_asserter for 200 checks, `count` and `check_ordering`. This allows two things: ensuring the amount of data returned in the list matches the amount expected, and allowing for a precise ordering check on returning data. This allows for better testing of filter/search fields objects, as it can ensure that only the data expected was returned.

In addition, the logic for asserting errors in the 400 range did not allow for checking non-vnd errors. This is an issue in the telemetry branch on Transmission, as the response is not `vnd` and therefore cannot be checked in the normal way, leading to inconsistencies in testing.