### PR TITLE
Refactor get_jwt_from_request to better handle unauthenticated requests

### DIFF
--- a/src/shipchain_common/authentication.py
+++ b/src/shipchain_common/authentication.py
@@ -37,7 +37,7 @@ def get_jwt_from_request(request):
     """
     This is for retrieving the decoded JWT from the a request via the simplejwt authenticator.
     """
-    if settings.PROFILES_ENABLED and request.user.is_authenticated:
+    if settings.PROFILES_ENABLED and request.user and request.user.is_authenticated:
         return (request.authenticators[-1].get_raw_token(request.authenticators[-1].get_header(request)).decode()
                 if request.authenticators else None)
     return None

--- a/src/shipchain_common/authentication.py
+++ b/src/shipchain_common/authentication.py
@@ -37,10 +37,10 @@ def get_jwt_from_request(request):
     """
     This is for retrieving the decoded JWT from the a request via the simplejwt authenticator.
     """
-    if not settings.PROFILES_ENABLED:
-        return None
-    return (request.authenticators[-1].get_raw_token(request.authenticators[-1].get_header(request)).decode()
-            if request.authenticators else None)
+    if settings.PROFILES_ENABLED and request.user.is_authenticated:
+        return (request.authenticators[-1].get_raw_token(request.authenticators[-1].get_header(request)).decode()
+                if request.authenticators else None)
+    return None
 
 
 def is_internal_call(request):


### PR DESCRIPTION
This change is as supplement to the `500` error message found in transmission and aims at avoiding any attempt to extract a raw `jwt` from the request object when either profiles is disabled or request is not authenticated.