### PR TITLE
Remove JSON Asserter pytest fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,5 @@ pytest-django = "^3.6"
 pytest-mock = "^1.10"
 safety = "^1.8"
 
-[tool.poetry.plugins."pytest11"]
-"modified_http_pretty" = "shipchain_common.test_utils.modified_http_pretty"
+#[tool.poetry.plugins."pytest11"]
+#"modified_http_pretty" = "shipchain_common.test_utils.modified_http_pretty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,3 @@ pytest-cov = "^2.6"
 pytest-django = "^3.6"
 pytest-mock = "^1.10"
 safety = "^1.8"
-
-#[tool.poetry.plugins."pytest11"]
-#"modified_http_pretty" = "shipchain_common.test_utils.modified_http_pretty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,4 +46,4 @@ pytest-mock = "^1.10"
 safety = "^1.8"
 
 [tool.poetry.plugins."pytest11"]
-"json_asserter" = "shipchain_common.test_utils.json_asserter"
+"modified_http_pretty" = "shipchain_common.test_utils.modified_http_pretty"

--- a/src/shipchain_common/test_utils/__init__.py
+++ b/src/shipchain_common/test_utils/__init__.py
@@ -16,10 +16,7 @@ limitations under the License.
 """
 
 from .json_asserter import \
-    json_asserter, \
-    AssertionHelper, \
-    JsonAsserterMixin
-
+    AssertionHelper
 from .helpers import\
     create_form_content, \
     datetimeAlmostEqual, \

--- a/src/shipchain_common/test_utils/json_asserter.py
+++ b/src/shipchain_common/test_utils/json_asserter.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import pytest
 from rest_framework import status
 
 # pylint: disable=too-many-branches
@@ -401,7 +400,9 @@ def assert_404(response, error='Not found', pointer=None, vnd=True):
     response_has_error(response, error, pointer, vnd)
 
 
-def assert_405(response, error='Method not allowed', pointer=None, vnd=True):
+def assert_405(response, error=None, pointer=None, vnd=True):
+    if error is None:
+        error = f'Method "{response.renderer_context["request"].method}" not allowed.'
     assert response is not None
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED, f'status_code {response.status_code} != 405'
     response_has_error(response, error, pointer, vnd)
@@ -435,14 +436,3 @@ class AssertionHelper:
 
     HTTP_500 = assert_500
     HTTP_503 = assert_503
-
-
-@pytest.fixture(scope='session')
-def json_asserter():
-    return AssertionHelper
-
-
-class JsonAsserterMixin:
-    @pytest.fixture(autouse=True)
-    def set_json_asserter(self, json_asserter):
-        self.json_asserter = json_asserter

--- a/tests/test_json_asserter.py
+++ b/tests/test_json_asserter.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 from rest_framework import status
-from shipchain_common.test_utils import AssertionHelper, JsonAsserterMixin
+from shipchain_common.test_utils import AssertionHelper
 
 EXAMPLE_PLAIN = {
     'id': '07b374c3-ed9b-4811-901a-d0c5d746f16a',
@@ -203,38 +203,35 @@ def json_error():
 
 
 @pytest.fixture
-def entity_ref_1(json_asserter):
-    return json_asserter.EntityRef(
+def entity_ref_1():
+    return AssertionHelper.EntityRef(
         resource=EXAMPLE_RESOURCE['type'],
         pk=EXAMPLE_RESOURCE['id'],
         attributes=EXAMPLE_RESOURCE['attributes'],
-        relationships={'owner': json_asserter.EntityRef(
+        relationships={'owner': AssertionHelper.EntityRef(
             resource=EXAMPLE_USER['type'],
             pk=EXAMPLE_USER['id'],
         )})
 
 
 @pytest.fixture
-def entity_ref_3(json_asserter):
-    return json_asserter.EntityRef(
+def entity_ref_3():
+    return AssertionHelper.EntityRef(
         resource=EXAMPLE_RESOURCE_3['type'],
         pk=EXAMPLE_RESOURCE_3['id'],
         attributes=EXAMPLE_RESOURCE_3['attributes'],
-        relationships={'owner': json_asserter.EntityRef(
+        relationships={'owner': AssertionHelper.EntityRef(
             resource=EXAMPLE_USER['type'],
             pk=EXAMPLE_USER['id'],
         )})
 
+
 class TestAssertionHelper:
-
-    @pytest.fixture(scope='session')
-    def json_asserter(self):
-        return AssertionHelper
-
     @pytest.fixture(autouse=True)
     def make_build_response(self):
         def _build_response(data, status_code=status.HTTP_200_OK):
             return Mock(status_code=status_code, json=lambda: data)
+
         self.build_response = _build_response
 
     @pytest.fixture
@@ -257,215 +254,215 @@ class TestAssertionHelper:
         vnd_error['errors'][0]['detail'] = 'Method not allowed'
         return vnd_error
 
-    def test_status_200(self, json_asserter, vnd_single, vnd_error_400):
+    def test_status_200(self, vnd_single, vnd_error_400):
         response = self.build_response(vnd_single)
-        json_asserter.HTTP_200(response)
+        AssertionHelper.HTTP_200(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
-            json_asserter.HTTP_200(response)
+            AssertionHelper.HTTP_200(response)
         assert 'status_code 400 != 200' in str(err.value)
 
-    def test_status_201(self, json_asserter, vnd_single, vnd_error_400):
+    def test_status_201(self, vnd_single, vnd_error_400):
         response = self.build_response(vnd_single, status_code=status.HTTP_201_CREATED)
-        json_asserter.HTTP_201(response)
+        AssertionHelper.HTTP_201(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
-            json_asserter.HTTP_201(response)
+            AssertionHelper.HTTP_201(response)
         assert 'status_code 400 != 201' in str(err.value)
 
-    def test_status_202(self, json_asserter, vnd_single, vnd_error_400):
+    def test_status_202(self, vnd_single, vnd_error_400):
         response = self.build_response(vnd_single, status_code=status.HTTP_202_ACCEPTED)
-        json_asserter.HTTP_202(response)
+        AssertionHelper.HTTP_202(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
-            json_asserter.HTTP_202(response)
+            AssertionHelper.HTTP_202(response)
         assert 'status_code 400 != 202' in str(err.value)
 
-    def test_status_204(self, json_asserter, vnd_single, vnd_error_400):
+    def test_status_204(self, vnd_single, vnd_error_400):
         response = self.build_response(vnd_single, status_code=status.HTTP_204_NO_CONTENT)
-        json_asserter.HTTP_204(response)
+        AssertionHelper.HTTP_204(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
-            json_asserter.HTTP_204(response)
+            AssertionHelper.HTTP_204(response)
         assert 'status_code 400 != 204' in str(err.value)
 
-    def test_status_400(self, json_asserter, vnd_single, vnd_error_400):
+    def test_status_400(self, vnd_single, vnd_error_400):
         response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
-        json_asserter.HTTP_400(response)
+        AssertionHelper.HTTP_400(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_single)
-            json_asserter.HTTP_400(response)
+            AssertionHelper.HTTP_400(response)
         assert 'status_code 200 != 400' in str(err.value)
 
-    def test_status_400_custom_message(self, json_asserter, vnd_error_400):
+    def test_status_400_custom_message(self, vnd_error_400):
         vnd_error_400['errors'][0]['detail'] = 'custom error message'
         response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
-        json_asserter.HTTP_400(response, error='custom error message')
+        AssertionHelper.HTTP_400(response, error='custom error message')
 
-    def test_status_400_custom_pointer(self, json_asserter, vnd_error_400):
+    def test_status_400_custom_pointer(self, vnd_error_400):
         vnd_error_400['errors'][0]['detail'] = 'custom error message'
         vnd_error_400['errors'][0]['source']['pointer'] = 'pointer'
         response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
-        json_asserter.HTTP_400(response, error='custom error message', pointer='pointer')
+        AssertionHelper.HTTP_400(response, error='custom error message', pointer='pointer')
 
-    def test_status_400_json(self, json_asserter, vnd_single, json_error):
+    def test_status_400_json(self, vnd_single, json_error):
         response = self.build_response(json_error, status_code=status.HTTP_400_BAD_REQUEST)
-        json_asserter.HTTP_400(response, error=json_error['detail'], vnd=False)
+        AssertionHelper.HTTP_400(response, error=json_error['detail'], vnd=False)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_200_OK)
-            json_asserter.HTTP_400(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_400(response, error='Different error', vnd=False)
         assert 'status_code 200 != 400' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_400_BAD_REQUEST)
-            json_asserter.HTTP_400(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_400(response, error='Different error', vnd=False)
         assert f'Error Different error not found in {json_error["detail"]}' in str(err.value)
 
-    def test_status_401(self, json_asserter, vnd_single, vnd_error_401):
+    def test_status_401(self, vnd_single, vnd_error_401):
         response = self.build_response(vnd_error_401, status_code=status.HTTP_401_UNAUTHORIZED)
-        json_asserter.HTTP_401(response)
+        AssertionHelper.HTTP_401(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_single)
-            json_asserter.HTTP_401(response)
+            AssertionHelper.HTTP_401(response)
         assert 'status_code 200 != 401' in str(err.value)
 
-    def test_status_401_json(self, json_asserter, vnd_single, json_error):
+    def test_status_401_json(self, vnd_single, json_error):
         response = self.build_response(json_error, status_code=status.HTTP_401_UNAUTHORIZED)
-        json_asserter.HTTP_401(response, error=json_error['detail'], vnd=False)
+        AssertionHelper.HTTP_401(response, error=json_error['detail'], vnd=False)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_200_OK)
-            json_asserter.HTTP_401(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_401(response, error='Different error', vnd=False)
         assert 'status_code 200 != 401' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_401_UNAUTHORIZED)
-            json_asserter.HTTP_401(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_401(response, error='Different error', vnd=False)
         assert f'Error Different error not found in {json_error["detail"]}' in str(err.value)
 
-    def test_status_403(self, json_asserter, vnd_single, vnd_error_403):
+    def test_status_403(self, vnd_single, vnd_error_403):
         response = self.build_response(vnd_error_403, status_code=status.HTTP_403_FORBIDDEN)
-        json_asserter.HTTP_403(response)
+        AssertionHelper.HTTP_403(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_single)
-            json_asserter.HTTP_403(response)
+            AssertionHelper.HTTP_403(response)
         assert 'status_code 200 != 403' in str(err.value)
 
-    def test_status_403_json(self, json_asserter, vnd_single, json_error):
+    def test_status_403_json(self, vnd_single, json_error):
         response = self.build_response(json_error, status_code=status.HTTP_403_FORBIDDEN)
-        json_asserter.HTTP_403(response, error=json_error['detail'], vnd=False)
+        AssertionHelper.HTTP_403(response, error=json_error['detail'], vnd=False)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_200_OK)
-            json_asserter.HTTP_403(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_403(response, error='Different error', vnd=False)
         assert 'status_code 200 != 403' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_403_FORBIDDEN)
-            json_asserter.HTTP_403(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_403(response, error='Different error', vnd=False)
         assert f'Error Different error not found in {json_error["detail"]}' in str(err.value)
 
-    def test_status_404(self, json_asserter, vnd_single, vnd_error_404):
+    def test_status_404(self, vnd_single, vnd_error_404):
         response = self.build_response(vnd_error_404, status_code=status.HTTP_404_NOT_FOUND)
-        json_asserter.HTTP_404(response)
+        AssertionHelper.HTTP_404(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_single)
-            json_asserter.HTTP_404(response)
+            AssertionHelper.HTTP_404(response)
         assert 'status_code 200 != 404' in str(err.value)
 
-    def test_status_404_json(self, json_asserter, vnd_single, json_error):
+    def test_status_404_json(self, vnd_single, json_error):
         response = self.build_response(json_error, status_code=status.HTTP_404_NOT_FOUND)
-        json_asserter.HTTP_404(response, error=json_error['detail'], vnd=False)
+        AssertionHelper.HTTP_404(response, error=json_error['detail'], vnd=False)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_200_OK)
-            json_asserter.HTTP_404(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_404(response, error='Different error', vnd=False)
         assert 'status_code 200 != 404' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_404_NOT_FOUND)
-            json_asserter.HTTP_404(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_404(response, error='Different error', vnd=False)
         assert f'Error Different error not found in {json_error["detail"]}' in str(err.value)
 
-    def test_status_405(self, json_asserter, vnd_single, vnd_error_405):
+    def test_status_405(self, vnd_single, vnd_error_405):
         response = self.build_response(vnd_error_405, status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
-        json_asserter.HTTP_405(response)
+        AssertionHelper.HTTP_405(response, error='Method not allowed')
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_single)
-            json_asserter.HTTP_405(response)
+            AssertionHelper.HTTP_405(response, error='Method not allowed')
         assert 'status_code 200 != 405' in str(err.value)
 
-    def test_status_405_json(self, json_asserter, vnd_single, json_error):
+    def test_status_405_json(self, vnd_single, json_error):
         response = self.build_response(json_error, status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
-        json_asserter.HTTP_405(response, error=json_error['detail'], vnd=False)
+        AssertionHelper.HTTP_405(response, error=json_error['detail'], vnd=False)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_200_OK)
-            json_asserter.HTTP_405(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_405(response, error='Different error', vnd=False)
         assert 'status_code 200 != 405' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(json_error, status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
-            json_asserter.HTTP_405(response, error='Different error', vnd=False)
+            AssertionHelper.HTTP_405(response, error='Different error', vnd=False)
         assert f'Error Different error not found in {json_error["detail"]}' in str(err.value)
 
-    def test_status_500(self, json_asserter, vnd_single, vnd_error):
+    def test_status_500(self, vnd_single, vnd_error):
         vnd_error['errors'][0]['detail'] = 'A server error occurred.'
         response = self.build_response(vnd_error, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-        json_asserter.HTTP_500(response)
+        AssertionHelper.HTTP_500(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_single)
-            json_asserter.HTTP_500(response)
+            AssertionHelper.HTTP_500(response)
         assert 'status_code 200 != 500' in str(err.value)
 
-    def test_status_500_custom_message(self, json_asserter, vnd_error):
+    def test_status_500_custom_message(self, vnd_error):
         vnd_error['errors'][0]['detail'] = 'custom error message'
         response = self.build_response(vnd_error, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-        json_asserter.HTTP_500(response, error='custom error message')
+        AssertionHelper.HTTP_500(response, error='custom error message')
 
-    def test_status_503(self, json_asserter, vnd_single, vnd_error):
+    def test_status_503(self, vnd_single, vnd_error):
         vnd_error['errors'][0]['detail'] = 'Service temporarily unavailable, try again later'
         response = self.build_response(vnd_error, status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
-        json_asserter.HTTP_503(response)
+        AssertionHelper.HTTP_503(response)
 
         with pytest.raises(AssertionError) as err:
             response = self.build_response(vnd_single)
-            json_asserter.HTTP_503(response)
+            AssertionHelper.HTTP_503(response)
         assert 'status_code 200 != 503' in str(err.value)
 
-    def test_status_503_custom_message(self, json_asserter, vnd_error):
+    def test_status_503_custom_message(self, vnd_error):
         vnd_error['errors'][0]['detail'] = 'custom error message'
         response = self.build_response(vnd_error, status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
-        json_asserter.HTTP_503(response, error='custom error message')
+        AssertionHelper.HTTP_503(response, error='custom error message')
 
-    def test_status_wrong_message(self, json_asserter, vnd_error_404):
+    def test_status_wrong_message(self, vnd_error_404):
         response = self.build_response(vnd_error_404, status_code=status.HTTP_404_NOT_FOUND)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_404(response, error='Not the correct error')
+            AssertionHelper.HTTP_404(response, error='Not the correct error')
         assert f'Error `Not the correct error` not found in' in str(err.value)
 
-    def test_status_400_wrong_pointer(self, json_asserter, vnd_error_400):
+    def test_status_400_wrong_pointer(self, vnd_error_400):
         vnd_error_400['errors'][0]['detail'] = 'custom error message'
         vnd_error_400['errors'][0]['source']['pointer'] = 'pointer'
         response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_400(response, error='custom error message', pointer='Not the correct pointer')
+            AssertionHelper.HTTP_400(response, error='custom error message', pointer='Not the correct pointer')
         assert f'Error `Not the correct pointer` not found in' in str(err.value)
 
-    def test_status_404_wrong_pointer(self, json_asserter, vnd_error):
+    def test_status_404_wrong_pointer(self, vnd_error):
         vnd_error['errors'][0]['detail'] = 'Not found'
         vnd_error['errors'][0]['source'] = {
             'pointer': 'correct pointer'
@@ -473,10 +470,10 @@ class TestAssertionHelper:
         response = self.build_response(vnd_error, status_code=status.HTTP_404_NOT_FOUND)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_404(response, pointer='Not the correct pointer')
+            AssertionHelper.HTTP_404(response, pointer='Not the correct pointer')
         assert f'Error `Not the correct pointer` not found in' in str(err.value)
 
-    def test_status_pointer_requires_correct_error(self, json_asserter, vnd_error):
+    def test_status_pointer_requires_correct_error(self, vnd_error):
         vnd_error['errors'][0]['detail'] = 'Not found'
         vnd_error['errors'][0]['source'] = {
             'pointer': 'correct pointer'
@@ -484,130 +481,130 @@ class TestAssertionHelper:
         response = self.build_response(vnd_error, status_code=status.HTTP_404_NOT_FOUND)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_404(response, error='Not the correct error', pointer='Not the correct pointer')
+            AssertionHelper.HTTP_404(response, error='Not the correct error', pointer='Not the correct pointer')
         assert f'Error `Not the correct error` not found in' in str(err.value)
 
-    def test_status_in_second_error(self, json_asserter, vnd_error_404):
+    def test_status_in_second_error(self, vnd_error_404):
         vnd_error_404['errors'].append({'detail': 'another error'})
         response = self.build_response(vnd_error_404, status_code=status.HTTP_404_NOT_FOUND)
 
-        json_asserter.HTTP_404(response, error='another error')
+        AssertionHelper.HTTP_404(response, error='another error')
 
-    def test_status_missing_in_multiple_errors(self, json_asserter, vnd_error_404):
+    def test_status_missing_in_multiple_errors(self, vnd_error_404):
         vnd_error_404['errors'].append({'detail': 'another error'})
         response = self.build_response(vnd_error_404, status_code=status.HTTP_404_NOT_FOUND)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_404(response, error='Not the correct error')
+            AssertionHelper.HTTP_404(response, error='Not the correct error')
         assert f'Error `Not the correct error` not found in' in str(err.value)
 
-    def test_exclusive_entity_refs_or_fields(self, json_asserter, vnd_single):
+    def test_exclusive_entity_refs_or_fields(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(), attributes={'test': 1})
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(), attributes={'test': 1})
         assert 'Use Only `entity_refs` or explicit `attributes`, `relationships`, `resource`, and `pk` but not both' \
                in str(err.value)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(), relationships={'test': 1})
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(), relationships={'test': 1})
         assert 'Use Only `entity_refs` or explicit `attributes`, `relationships`, `resource`, and `pk` but not both' \
                in str(err.value)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(), resource='test')
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(), resource='test')
         assert 'Use Only `entity_refs` or explicit `attributes`, `relationships`, `resource`, and `pk` but not both' \
                in str(err.value)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(), pk='test')
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(), pk='test')
         assert 'Use Only `entity_refs` or explicit `attributes`, `relationships`, `resource`, and `pk` but not both' \
                in str(err.value)
 
-    def test_vnd_with_non_jsonapi_data(self, json_asserter):
+    def test_vnd_with_non_jsonapi_data(self):
         response = self.build_response(EXAMPLE_PLAIN)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, attributes=EXAMPLE_PLAIN)
+            AssertionHelper.HTTP_200(response, attributes=EXAMPLE_PLAIN)
         assert f'response does not contain `data` property' in str(err.value)
 
-    def test_vnd_is_list(self, json_asserter, vnd_single, vnd_list):
+    def test_vnd_is_list(self, vnd_single, vnd_list):
         single_response = self.build_response(vnd_single)
         list_response = self.build_response(vnd_list)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(single_response, is_list=True)
+            AssertionHelper.HTTP_200(single_response, is_list=True)
         assert 'Response should be a list' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(list_response)
+            AssertionHelper.HTTP_200(list_response)
         assert 'Response should not be a list' in str(err.value)
 
-    def test_vnd_attributes_match(self, json_asserter, vnd_single):
+    def test_vnd_attributes_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        json_asserter.HTTP_200(response, attributes=EXAMPLE_RESOURCE['attributes'])
+        AssertionHelper.HTTP_200(response, attributes=EXAMPLE_RESOURCE['attributes'])
 
-    def test_vnd_attributes_not_match(self, json_asserter, vnd_single):
+    def test_vnd_attributes_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, attributes=EXAMPLE_RESOURCE_2['attributes'])
+            AssertionHelper.HTTP_200(response, attributes=EXAMPLE_RESOURCE_2['attributes'])
         assert f'Attribute Value incorrect `{EXAMPLE_RESOURCE_2["attributes"]["name"]}` in ' in str(err.value)
 
-    def test_vnd_relationships_should_be_entity_ref(self, json_asserter, vnd_single):
+    def test_vnd_relationships_should_be_entity_ref(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, relationships={'owner': EXAMPLE_RESOURCE_2})
+            AssertionHelper.HTTP_200(response, relationships={'owner': EXAMPLE_RESOURCE_2})
         assert f'asserted relationship is not an EntityRef' in str(err.value)
 
-    def test_vnd_relationships_match(self, json_asserter, vnd_single):
+    def test_vnd_relationships_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
-        json_asserter.HTTP_200(response, relationships={'owner': json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, relationships={'owner': AssertionHelper.EntityRef(
             resource=EXAMPLE_USER['type'],
             pk=EXAMPLE_USER['id'],
         )})
 
-    def test_vnd_relationships_match_list(self, json_asserter, vnd_single):
+    def test_vnd_relationships_match_list(self, vnd_single):
         response = self.build_response(vnd_single)
 
-        json_asserter.HTTP_200(response, relationships={
-            'owner': json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, relationships={
+            'owner': AssertionHelper.EntityRef(
                 resource=EXAMPLE_USER['type'],
                 pk=EXAMPLE_USER['id'],
             ),
             'children': [
-                json_asserter.EntityRef(
+                AssertionHelper.EntityRef(
                     resource=EXAMPLE_RESOURCE_2['type'],
                     pk=EXAMPLE_RESOURCE_2['id'],
                 ),
-                json_asserter.EntityRef(
+                AssertionHelper.EntityRef(
                     resource=EXAMPLE_RESOURCE_4['type'],
                     pk=EXAMPLE_RESOURCE_4['id'],
                 ),
             ]})
 
-    def test_vnd_relationships_not_match(self, json_asserter, vnd_single):
+    def test_vnd_relationships_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, relationships={'owner': json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, relationships={'owner': AssertionHelper.EntityRef(
                 resource=EXAMPLE_RESOURCE['type'],
                 pk=EXAMPLE_RESOURCE['id'],
             )})
         assert f'EntityRef resource type `{EXAMPLE_RESOURCE["type"]}` does not match' in str(err.value)
 
-    def test_vnd_relationships_not_match_in_list(self, json_asserter, vnd_single):
+    def test_vnd_relationships_not_match_in_list(self, vnd_single):
         response = self.build_response(vnd_single)
 
-        relationship = json_asserter.EntityRef(resource=EXAMPLE_RESOURCE_3["type"],
-                                               pk=EXAMPLE_RESOURCE_3["id"],
-                                               attributes={})
+        relationship = AssertionHelper.EntityRef(resource=EXAMPLE_RESOURCE_3["type"],
+                                                 pk=EXAMPLE_RESOURCE_3["id"],
+                                                 attributes={})
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, relationships={'children': [
-                json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, relationships={'children': [
+                AssertionHelper.EntityRef(
                     resource=EXAMPLE_RESOURCE_2['type'],
                     pk=EXAMPLE_RESOURCE_2['id'],
                 ),
@@ -615,362 +612,363 @@ class TestAssertionHelper:
             ]})
         assert f'{relationship} NOT IN ' in str(err.value)
 
-    def test_vnd_included_should_be_entity_ref(self, json_asserter, vnd_single):
+    def test_vnd_included_should_be_entity_ref(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, included=EXAMPLE_RESOURCE_2)
+            AssertionHelper.HTTP_200(response, included=EXAMPLE_RESOURCE_2)
         assert f'asserted includes is not an EntityRef' in str(err.value)
 
-    def test_vnd_included_full_match(self, json_asserter, vnd_single):
+    def test_vnd_included_full_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
-        json_asserter.HTTP_200(response, included=json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, included=AssertionHelper.EntityRef(
             resource=EXAMPLE_RESOURCE_2['type'],
             pk=EXAMPLE_RESOURCE_2['id'],
             attributes=EXAMPLE_RESOURCE_2['attributes'],
         ))
 
-    def test_vnd_included_full_not_match(self, json_asserter, vnd_single):
+    def test_vnd_included_full_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        include = json_asserter.EntityRef(
-                resource=EXAMPLE_RESOURCE['type'],
-                pk=EXAMPLE_RESOURCE['id'],
-                attributes=EXAMPLE_RESOURCE['attributes'],
-            )
+        include = AssertionHelper.EntityRef(
+            resource=EXAMPLE_RESOURCE['type'],
+            pk=EXAMPLE_RESOURCE['id'],
+            attributes=EXAMPLE_RESOURCE['attributes'],
+        )
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, included=include)
+            AssertionHelper.HTTP_200(response, included=include)
         assert f'{include} NOT IN' in str(err.value)
 
-    def test_vnd_included_type_pk_match(self, json_asserter, vnd_single):
+    def test_vnd_included_type_pk_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
-        json_asserter.HTTP_200(response, included=json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, included=AssertionHelper.EntityRef(
             resource=EXAMPLE_RESOURCE_2['type'],
             pk=EXAMPLE_RESOURCE_2['id'],
         ))
 
-    def test_vnd_included_type_pk_not_match(self, json_asserter, vnd_single):
+    def test_vnd_included_type_pk_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        include = json_asserter.EntityRef(
-                resource=EXAMPLE_RESOURCE['type'],
-                pk=EXAMPLE_RESOURCE['id'],
-            )
+        include = AssertionHelper.EntityRef(
+            resource=EXAMPLE_RESOURCE['type'],
+            pk=EXAMPLE_RESOURCE['id'],
+        )
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, included=include)
+            AssertionHelper.HTTP_200(response, included=include)
         assert f'{include} NOT IN' in str(err.value)
 
-    def test_vnd_included_attributes_match(self, json_asserter, vnd_single):
+    def test_vnd_included_attributes_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
-        json_asserter.HTTP_200(response, included=json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, included=AssertionHelper.EntityRef(
             attributes=EXAMPLE_RESOURCE_2['attributes'],
         ))
 
-    def test_vnd_included_attributes_not_match(self, json_asserter, vnd_single):
+    def test_vnd_included_attributes_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        include = json_asserter.EntityRef(
-                attributes=EXAMPLE_RESOURCE['attributes'],
-            )
+        include = AssertionHelper.EntityRef(
+            attributes=EXAMPLE_RESOURCE['attributes'],
+        )
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, included=include)
+            AssertionHelper.HTTP_200(response, included=include)
         assert f'{include} NOT IN' in str(err.value)
 
-    def test_vnd_included_list_all_match(self, json_asserter, vnd_single):
+    def test_vnd_included_list_all_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
-        json_asserter.HTTP_200(response, included=[
-            json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, included=[
+            AssertionHelper.EntityRef(
                 resource=EXAMPLE_RESOURCE_2['type'],
                 pk=EXAMPLE_RESOURCE_2['id'],
                 attributes=EXAMPLE_RESOURCE_2['attributes']),
-            json_asserter.EntityRef(
+            AssertionHelper.EntityRef(
                 resource=EXAMPLE_USER['type'],
                 pk=EXAMPLE_USER['id'],
                 attributes=EXAMPLE_USER['attributes']),
-            ])
+        ])
 
-    def test_vnd_included_list_one_match(self, json_asserter, vnd_single):
+    def test_vnd_included_list_one_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        include_1 = json_asserter.EntityRef(
+        include_1 = AssertionHelper.EntityRef(
             resource=EXAMPLE_RESOURCE['type'],
             pk=EXAMPLE_RESOURCE['id'],
             attributes=EXAMPLE_RESOURCE['attributes'])
-        include_2 = json_asserter.EntityRef(
+        include_2 = AssertionHelper.EntityRef(
             resource=EXAMPLE_USER['type'],
             pk=EXAMPLE_USER['id'],
             attributes=EXAMPLE_USER['attributes'])
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, included=[include_1, include_2])
+            AssertionHelper.HTTP_200(response, included=[include_1, include_2])
         assert f'{include_1} NOT IN' in str(err.value)
 
-    def test_vnd_included_list_none_match(self, json_asserter, vnd_single):
+    def test_vnd_included_list_none_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        include_1 = json_asserter.EntityRef(
+        include_1 = AssertionHelper.EntityRef(
             resource=EXAMPLE_RESOURCE['type'],
             pk=EXAMPLE_RESOURCE['id'],
             attributes=EXAMPLE_RESOURCE['attributes'])
-        include_2 = json_asserter.EntityRef(
+        include_2 = AssertionHelper.EntityRef(
             resource=EXAMPLE_RESOURCE_3['type'],
             pk=EXAMPLE_RESOURCE_3['id'],
             attributes=EXAMPLE_RESOURCE_3['attributes'])
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, included=[include_1, include_2])
+            AssertionHelper.HTTP_200(response, included=[include_1, include_2])
         assert f'{include_1} NOT IN' in str(err.value)
 
-    def test_entity_list_non_list_response(self, json_asserter, vnd_single):
+    def test_entity_list_non_list_response(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=[json_asserter.EntityRef()])
+            AssertionHelper.HTTP_200(response, entity_refs=[AssertionHelper.EntityRef()])
         assert 'entity_refs should not be a list for a non-list response' in str(err.value)
 
-    def test_vnd_entity_full_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_full_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
             resource=EXAMPLE_RESOURCE['type'],
             pk=EXAMPLE_RESOURCE['id'],
             attributes=EXAMPLE_RESOURCE['attributes'],
-            relationships={'owner': json_asserter.EntityRef(
+            relationships={'owner': AssertionHelper.EntityRef(
                 resource=EXAMPLE_USER['type'],
                 pk=EXAMPLE_USER['id'],
             )}
         ))
 
-    def test_vnd_entity_full_type_not_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_full_type_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
                 resource=EXAMPLE_USER['type'],
                 pk=EXAMPLE_RESOURCE['id'],
                 attributes=EXAMPLE_RESOURCE['attributes'],
-                relationships={'owner': json_asserter.EntityRef(
+                relationships={'owner': AssertionHelper.EntityRef(
                     resource=EXAMPLE_USER['type'],
                     pk=EXAMPLE_USER['id'],
                 )}
             ))
         assert f'Invalid Resource Type in' in str(err.value)
 
-    def test_vnd_entity_full_id_not_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_full_id_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
                 resource=EXAMPLE_RESOURCE['type'],
                 pk=EXAMPLE_USER['id'],
                 attributes=EXAMPLE_RESOURCE['attributes'],
-                relationships={'owner': json_asserter.EntityRef(
+                relationships={'owner': AssertionHelper.EntityRef(
                     resource=EXAMPLE_USER['type'],
                     pk=EXAMPLE_USER['id'],
                 )}
             ))
         assert f'Invalid ID in' in str(err.value)
 
-    def test_vnd_entity_full_attributes_missing(self, json_asserter, vnd_single):
+    def test_vnd_entity_full_attributes_missing(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
                 resource=EXAMPLE_RESOURCE['type'],
                 pk=EXAMPLE_RESOURCE['id'],
                 attributes=EXAMPLE_USER['attributes'],
-                relationships={'owner': json_asserter.EntityRef(
+                relationships={'owner': AssertionHelper.EntityRef(
                     resource=EXAMPLE_USER['type'],
                     pk=EXAMPLE_USER['id'],
                 )}
             ))
         assert f'Missing Attribute `username` in' in str(err.value)
 
-    def test_vnd_entity_full_attributes_not_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_full_attributes_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
                 resource=EXAMPLE_RESOURCE['type'],
                 pk=EXAMPLE_RESOURCE['id'],
                 attributes=EXAMPLE_RESOURCE_2['attributes'],
-                relationships={'owner': json_asserter.EntityRef(
+                relationships={'owner': AssertionHelper.EntityRef(
                     resource=EXAMPLE_USER['type'],
                     pk=EXAMPLE_USER['id'],
                 )}
             ))
         assert f'Attribute Value incorrect `example 2` in' in str(err.value)
 
-    def test_vnd_entity_full_relationships_type_not_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_full_relationships_type_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
                 resource=EXAMPLE_RESOURCE['type'],
                 pk=EXAMPLE_RESOURCE['id'],
                 attributes=EXAMPLE_RESOURCE['attributes'],
-                relationships={'owner': json_asserter.EntityRef(
+                relationships={'owner': AssertionHelper.EntityRef(
                     resource=EXAMPLE_RESOURCE['type'],
                     pk=EXAMPLE_USER['id'],
                 )}
             ))
         assert f'EntityRef resource type `{EXAMPLE_RESOURCE["type"]}` does not match' in str(err.value)
 
-    def test_vnd_entity_full_relationships_pk_not_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_full_relationships_pk_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
                 resource=EXAMPLE_RESOURCE['type'],
                 pk=EXAMPLE_RESOURCE['id'],
                 attributes=EXAMPLE_RESOURCE['attributes'],
-                relationships={'owner': json_asserter.EntityRef(
+                relationships={'owner': AssertionHelper.EntityRef(
                     resource=EXAMPLE_USER['type'],
                     pk=EXAMPLE_RESOURCE['id'],
                 )}
             ))
         assert f'EntityRef ID `{EXAMPLE_RESOURCE["id"]}` does not match' in str(err.value)
 
-    def test_vnd_entity_type_pk_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_type_pk_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
             resource=EXAMPLE_RESOURCE['type'],
             pk=EXAMPLE_RESOURCE['id'],
         ))
 
-    def test_vnd_entity_type_pk_not_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_type_pk_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
                 resource=EXAMPLE_USER['type'],
                 pk=EXAMPLE_RESOURCE['id'],
             ))
         assert f'Invalid Resource Type in' in str(err.value)
 
-    def test_vnd_entity_attribute_only_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_attribute_only_match(self, vnd_single):
         response = self.build_response(vnd_single)
-        json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
             attributes=EXAMPLE_RESOURCE['attributes']
         ))
 
-    def test_vnd_entity_attribute_only_not_match(self, json_asserter, vnd_single):
+    def test_vnd_entity_attribute_only_not_match(self, vnd_single):
         response = self.build_response(vnd_single)
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=json_asserter.EntityRef(
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
                 attributes=EXAMPLE_RESOURCE_2['attributes'],
             ))
         assert f'Attribute Value incorrect `example 2` in' in str(err.value)
 
-    def test_vnd_list_entity_full_match(self, json_asserter, vnd_list):
+    def test_vnd_list_entity_full_match(self, vnd_list):
         response = self.build_response(vnd_list)
-        json_asserter.HTTP_200(response, is_list=True, entity_refs=json_asserter.EntityRef(
+        AssertionHelper.HTTP_200(response, is_list=True, entity_refs=AssertionHelper.EntityRef(
             resource=EXAMPLE_RESOURCE['type'],
             pk=EXAMPLE_RESOURCE['id'],
             attributes=EXAMPLE_RESOURCE['attributes'],
-            relationships={'owner': json_asserter.EntityRef(
+            relationships={'owner': AssertionHelper.EntityRef(
                 resource=EXAMPLE_USER['type'],
                 pk=EXAMPLE_USER['id'],
             )}
         ))
 
-    def test_vnd_list_entity_list_all_match(self, json_asserter, vnd_list, entity_ref_1, entity_ref_3):
+    def test_vnd_list_entity_list_all_match(self, vnd_list, entity_ref_1, entity_ref_3):
         response = self.build_response(vnd_list)
-        json_asserter.HTTP_200(response, is_list=True, entity_refs=[entity_ref_1, entity_ref_3])
+        AssertionHelper.HTTP_200(response, is_list=True, entity_refs=[entity_ref_1, entity_ref_3])
 
-    def test_vnd_list_count(self, json_asserter, vnd_list):
+    def test_vnd_list_count(self, vnd_list):
         response = self.build_response(vnd_list)
-        json_asserter.HTTP_200(response, is_list=True, count=len(vnd_list['data']))
+        AssertionHelper.HTTP_200(response, is_list=True, count=len(vnd_list['data']))
 
-    def test_vnd_list_wrong_count(self, json_asserter, vnd_list):
+    def test_vnd_list_wrong_count(self, vnd_list):
         list_length = len(vnd_list['data'])
         response = self.build_response(vnd_list)
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, is_list=True, count=list_length - 1)
+            AssertionHelper.HTTP_200(response, is_list=True, count=list_length - 1)
         assert f'Difference in count of response_data, got {list_length} expected {list_length - 1}' in str(err.value)
 
-    def test_vnd_single_count(self, json_asserter, vnd_single):
+    def test_vnd_single_count(self, vnd_single):
         response = self.build_response(vnd_single)
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, count=1)
+            AssertionHelper.HTTP_200(response, count=1)
         assert f'Count is only checked when response is list' in str(err.value)
 
-    def test_vnd_list_ordering(self, json_asserter, vnd_list, entity_ref_1, entity_ref_3):
+    def test_vnd_list_ordering(self, vnd_list, entity_ref_1, entity_ref_3):
         response = self.build_response(vnd_list)
-        json_asserter.HTTP_200(response, is_list=True, entity_refs=[entity_ref_1, entity_ref_3], check_ordering=True)
+        AssertionHelper.HTTP_200(response, is_list=True, entity_refs=[entity_ref_1, entity_ref_3], check_ordering=True)
 
-    def test_vnd_list_wrong_ordering(self, json_asserter, vnd_list, entity_ref_1, entity_ref_3):
+    def test_vnd_list_wrong_ordering(self, vnd_list, entity_ref_1, entity_ref_3):
         response = self.build_response(vnd_list)
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, is_list=True, entity_refs=[entity_ref_3, entity_ref_1], check_ordering=True)
+            AssertionHelper.HTTP_200(response, is_list=True, entity_refs=[entity_ref_3, entity_ref_1],
+                                     check_ordering=True)
         assert 'Invalid ID in ' in str(err.value)
 
-    def test_vnd_list_wrong_ordering_amount(self, json_asserter, vnd_list, entity_ref_1, entity_ref_3):
+    def test_vnd_list_wrong_ordering_amount(self, vnd_list, entity_ref_1, entity_ref_3):
         response = self.build_response(vnd_list)
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, is_list=True, entity_refs=[entity_ref_1, entity_ref_3, entity_ref_1],
-                                   check_ordering=True)
+            AssertionHelper.HTTP_200(response, is_list=True, entity_refs=[entity_ref_1, entity_ref_3, entity_ref_1],
+                                     check_ordering=True)
         assert 'Error: more entity refs supplied than available in response data. ' in str(err.value)
 
-    def test_vnd_single_ordering(self, json_asserter, vnd_single, entity_ref_1):
+    def test_vnd_single_ordering(self, vnd_single, entity_ref_1):
         response = self.build_response(vnd_single)
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, entity_refs=entity_ref_1, check_ordering=True)
+            AssertionHelper.HTTP_200(response, entity_refs=entity_ref_1, check_ordering=True)
         assert f'Ordering is only checked when response is list' in str(err.value)
 
-    def test_vnd_list_entity_list_one_not_match(self, json_asserter, vnd_list, entity_ref_1, entity_ref_3):
+    def test_vnd_list_entity_list_one_not_match(self, vnd_list, entity_ref_1, entity_ref_3):
         response = self.build_response(vnd_list)
         entity_ref_3.pk = EXAMPLE_RESOURCE_2['id']
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, is_list=True, entity_refs=[entity_ref_1, entity_ref_3])
+            AssertionHelper.HTTP_200(response, is_list=True, entity_refs=[entity_ref_1, entity_ref_3])
         assert f'{entity_ref_3} NOT IN' in str(err.value)
 
-    def test_plain_json_valid_parameters(self, json_asserter):
+    def test_plain_json_valid_parameters(self):
         response = self.build_response(EXAMPLE_PLAIN)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, entity_refs={json_asserter.EntityRef()})
+            AssertionHelper.HTTP_200(response, vnd=False, entity_refs={AssertionHelper.EntityRef()})
         assert f'entity_refs not valid when vnd=False' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, relationships=json_asserter.EntityRef())
+            AssertionHelper.HTTP_200(response, vnd=False, relationships=AssertionHelper.EntityRef())
         assert f'relationships not valid when vnd=False' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, included=json_asserter.EntityRef())
+            AssertionHelper.HTTP_200(response, vnd=False, included=AssertionHelper.EntityRef())
         assert f'included not valid when vnd=False' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False)
+            AssertionHelper.HTTP_200(response, vnd=False)
         assert f'attributes must be provided when vnd=False' in str(err.value)
 
-    def test_plain_json_attributes(self, json_asserter):
+    def test_plain_json_attributes(self):
         response = self.build_response(EXAMPLE_PLAIN)
 
-        json_asserter.HTTP_200(response, vnd=False, attributes=EXAMPLE_PLAIN)
+        AssertionHelper.HTTP_200(response, vnd=False, attributes=EXAMPLE_PLAIN)
 
-    def test_plain_json_attributes_top_level_missing(self, json_asserter):
+    def test_plain_json_attributes_top_level_missing(self):
         response = self.build_response(EXAMPLE_PLAIN)
 
         invalid_attributes = EXAMPLE_PLAIN.copy()
         invalid_attributes['new_field'] = 1
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, attributes=invalid_attributes)
+            AssertionHelper.HTTP_200(response, vnd=False, attributes=invalid_attributes)
         assert f'Missing Attribute `new_field` in ' in str(err.value)
 
-    def test_plain_json_attributes_top_level_mismatch(self, json_asserter):
+    def test_plain_json_attributes_top_level_mismatch(self):
         response = self.build_response(EXAMPLE_PLAIN)
 
         invalid_attributes = EXAMPLE_PLAIN.copy()
         invalid_attributes['id'] = 1
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, attributes=invalid_attributes)
+            AssertionHelper.HTTP_200(response, vnd=False, attributes=invalid_attributes)
         assert f'Attribute Value incorrect `1` in ' in str(err.value)
 
-    def test_plain_json_attributes_nested_missing(self, json_asserter):
+    def test_plain_json_attributes_nested_missing(self):
         response = self.build_response(EXAMPLE_PLAIN)
 
         invalid_attributes = EXAMPLE_PLAIN.copy()
@@ -978,10 +976,10 @@ class TestAssertionHelper:
         invalid_attributes['owner']['new_field'] = 'test'
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, attributes=invalid_attributes)
+            AssertionHelper.HTTP_200(response, vnd=False, attributes=invalid_attributes)
         assert f'Missing Attribute `new_field` in ' in str(err.value)
 
-    def test_plain_json_attributes_nested_mismatch(self, json_asserter):
+    def test_plain_json_attributes_nested_mismatch(self):
         response = self.build_response(EXAMPLE_PLAIN)
 
         invalid_attributes = EXAMPLE_PLAIN.copy()
@@ -989,61 +987,61 @@ class TestAssertionHelper:
         invalid_attributes['owner']['id'] = 'test'
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, attributes=invalid_attributes)
+            AssertionHelper.HTTP_200(response, vnd=False, attributes=invalid_attributes)
         assert f'Missing Attribute `id` in ' in str(err.value)
 
-    def test_plain_json_attributes_list_assertions(self, json_asserter):
+    def test_plain_json_attributes_list_assertions(self):
         single_response = self.build_response(EXAMPLE_PLAIN)
         list_response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(single_response, vnd=False, is_list=True, attributes=EXAMPLE_PLAIN)
+            AssertionHelper.HTTP_200(single_response, vnd=False, is_list=True, attributes=EXAMPLE_PLAIN)
         assert f'Response should be a list' in str(err.value)
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(list_response, vnd=False, attributes=EXAMPLE_PLAIN)
+            AssertionHelper.HTTP_200(list_response, vnd=False, attributes=EXAMPLE_PLAIN)
         assert f'Response should not be a list' in str(err.value)
 
-    def test_plain_json_attributes_list_single_match(self, json_asserter):
+    def test_plain_json_attributes_list_single_match(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
-        json_asserter.HTTP_200(response, vnd=False, is_list=True, attributes=EXAMPLE_PLAIN)
+        AssertionHelper.HTTP_200(response, vnd=False, is_list=True, attributes=EXAMPLE_PLAIN)
 
-    def test_plain_json_attributes_list_both_match(self, json_asserter):
+    def test_plain_json_attributes_list_both_match(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
-        json_asserter.HTTP_200(response, vnd=False, is_list=True, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
+        AssertionHelper.HTTP_200(response, vnd=False, is_list=True, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
-    def test_plain_json_attributes_list_one_missing(self, json_asserter):
+    def test_plain_json_attributes_list_one_missing(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, is_list=True, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_3])
+            AssertionHelper.HTTP_200(response, vnd=False, is_list=True, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_3])
         assert f'{EXAMPLE_PLAIN_3} NOT IN ' in str(err.value)
 
-    def test_plain_json_attributes_list_ordering(self, json_asserter):
+    def test_plain_json_attributes_list_ordering(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
-        json_asserter.HTTP_200(response, vnd=False, is_list=True, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2],
-                               check_ordering=True)
+        AssertionHelper.HTTP_200(response, vnd=False, is_list=True, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2],
+                                 check_ordering=True)
 
-    def test_plain_json_attributes_list_wrong_ordering(self, json_asserter):
+    def test_plain_json_attributes_list_wrong_ordering(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, is_list=True, attributes=[EXAMPLE_PLAIN_2, EXAMPLE_PLAIN],
-                                   check_ordering=True)
+            AssertionHelper.HTTP_200(response, vnd=False, is_list=True, attributes=[EXAMPLE_PLAIN_2, EXAMPLE_PLAIN],
+                                     check_ordering=True)
         assert f'Attribute Value incorrect ' in str(err.value)
 
-    def test_plain_json_attributes_list_wrong_ordering_size(self, json_asserter):
+    def test_plain_json_attributes_list_wrong_ordering_size(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, is_list=True, check_ordering=True,
-                                   attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2, EXAMPLE_PLAIN])
+            AssertionHelper.HTTP_200(response, vnd=False, is_list=True, check_ordering=True,
+                                     attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2, EXAMPLE_PLAIN])
         assert 'Error: more attributes supplied than available in response. 3 found asserted 2' in str(err.value)
 
-    def test_plain_json_attributes_list_nested_missing(self, json_asserter):
+    def test_plain_json_attributes_list_nested_missing(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
         invalid_attributes = EXAMPLE_PLAIN.copy()
@@ -1051,10 +1049,10 @@ class TestAssertionHelper:
         invalid_attributes['owner']['new_field'] = 'test'
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, is_list=True, attributes=invalid_attributes)
+            AssertionHelper.HTTP_200(response, vnd=False, is_list=True, attributes=invalid_attributes)
         assert f'{invalid_attributes} NOT IN ' in str(err.value)
 
-    def test_plain_json_attributes_list_nested_mismatch(self, json_asserter):
+    def test_plain_json_attributes_list_nested_mismatch(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
         invalid_attributes = EXAMPLE_PLAIN.copy()
@@ -1062,42 +1060,23 @@ class TestAssertionHelper:
         invalid_attributes['owner']['id'] = 'test'
 
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, is_list=True, attributes=invalid_attributes)
+            AssertionHelper.HTTP_200(response, vnd=False, is_list=True, attributes=invalid_attributes)
         assert f'{invalid_attributes} NOT IN ' in str(err.value)
 
-    def test_plain_json_list_count(self, json_asserter):
+    def test_plain_json_list_count(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
-        json_asserter.HTTP_200(response, vnd=False, is_list=True, count=2, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
+        AssertionHelper.HTTP_200(response, vnd=False, is_list=True, count=2,
+                                 attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
 
-    def test_plain_json_list_wrong_count(self, json_asserter):
+    def test_plain_json_list_wrong_count(self):
         response = self.build_response([EXAMPLE_PLAIN, EXAMPLE_PLAIN_2])
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, vnd=False, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2], is_list=True,
-                                   count=1)
+            AssertionHelper.HTTP_200(response, vnd=False, attributes=[EXAMPLE_PLAIN, EXAMPLE_PLAIN_2], is_list=True,
+                                     count=1)
         assert 'Difference in count of response_data, got 2 expected 1' in str(err.value)
 
-    def test_plain_json_single_count(self, json_asserter, vnd_single):
+    def test_plain_json_single_count(self, vnd_single):
         response = self.build_response(vnd_single)
         with pytest.raises(AssertionError) as err:
-            json_asserter.HTTP_200(response, count=1)
+            AssertionHelper.HTTP_200(response, count=1)
         assert f'Count is only checked when response is list' in str(err.value)
-
-
-class TestJsonAsserterMixin(JsonAsserterMixin):
-    def test_has_asserter(self):
-        assert hasattr(self, 'json_asserter')
-
-    @pytest.fixture(autouse=True)
-    def make_build_response(self):
-        def _build_response(data, status_code=status.HTTP_200_OK):
-            return Mock(status_code=status_code, json=lambda: data)
-        self.build_response = _build_response
-
-    def test_status_200(self, vnd_single, vnd_error_400):
-        response = self.build_response(vnd_single)
-        self.json_asserter.HTTP_200(response)
-
-        with pytest.raises(AssertionError) as err:
-            response = self.build_response(vnd_error_400, status_code=status.HTTP_400_BAD_REQUEST)
-            self.json_asserter.HTTP_200(response)
-        assert 'status_code 400 != 200' in str(err.value)


### PR DESCRIPTION
This branch removes the `json_asserter` pytest fixture, requiring that every use of the asserter be replaced with `AssertionHelper`.
This also changes the default error code for `405` to by dynamic with the request method sent in.