### PR TITLE
Add meta field to entity ref and to asserter

### DIFF
--- a/src/shipchain_common/test_utils/json_asserter.py
+++ b/src/shipchain_common/test_utils/json_asserter.py
@@ -21,11 +21,12 @@ from rest_framework import status
 
 
 class EntityReferenceClass:
-    def __init__(self, resource=None, pk=None, attributes=None, relationships=None):
+    def __init__(self, resource=None, pk=None, attributes=None, relationships=None, meta=None):
         self.resource = resource
         self.pk = pk
         self.attributes = attributes
         self.relationships = relationships
+        self.meta = meta
 
     def __str__(self):
         return f'Type: {self.resource}; ID: {self.pk}; ' \
@@ -158,6 +159,21 @@ def _vnd_assert_relationships(response_data, relationships):
                             f'EntityRef ID `{relationship_ref.pk}` does not match {response_relationships}'
 
 
+def _vnd_assert_meta(response_data, meta_data):
+    """
+    Scan response data for meta data
+    """
+    assert 'meta' in response_data, f'Meta missing in {response_data}'
+    assert isinstance(meta_data, dict), f'Invalid format for meta data {type(meta_data)}, must be dict'
+
+    response_meta = response_data['meta']
+
+    for key, value in meta_data.items():
+        assert key in response_meta, f'Meta field `{key}` not found in {response_meta}'
+        assert response_meta[key] == value,\
+            f'Meta field `{key}` had value `{response_meta[key]}` not `{value}` as expected.'
+
+
 def _vnd_assert_include(response, included):
     """
     Scan a response for all included resources
@@ -186,6 +202,9 @@ def _vnd_assertions(response_data, entity_ref):
 
     if entity_ref.relationships:
         _vnd_assert_relationships(response_data, entity_ref.relationships)
+
+    if entity_ref.meta:
+        _vnd_assert_meta(response_data, entity_ref.meta)
 
 
 def _plain_assert_attributes_in_response(response, attributes):

--- a/src/shipchain_common/test_utils/json_asserter.py
+++ b/src/shipchain_common/test_utils/json_asserter.py
@@ -101,7 +101,10 @@ def _vnd_assert_entity_ref_in_list(response_list, entity_ref, skip_attributes_pr
                         f'List Attribute key `{attr_key}` missing in {response_single}'
                     assert response_single['attributes'][attr_key] == attr_value, \
                         f'List Attribute Value incorrect `{attr_value}` in {response_single}'
+                if entity_ref.meta:
+                    _vnd_assert_meta(response_single, entity_ref.meta)
                 break
+
         else:
             single_attribute_failed = False
 
@@ -112,6 +115,9 @@ def _vnd_assert_entity_ref_in_list(response_list, entity_ref, skip_attributes_pr
                 elif response_single['attributes'][attr_key] != attr_value:
                     single_attribute_failed = True
                     break
+
+            if entity_ref.meta:
+                _vnd_assert_meta(response_single, entity_ref.meta)
 
             if not single_attribute_failed:
                 found_include = True

--- a/tests/test_json_asserter.py
+++ b/tests/test_json_asserter.py
@@ -145,6 +145,10 @@ def vnd_list():
                             }
                         ]
                     }
+                },
+                'meta': {
+                    'key': 'value',
+                    'other_key': 'other_value',
                 }
             },
             {
@@ -1138,4 +1142,49 @@ class TestAssertionHelper:
                     'key': 'value'
                 }],
              ))
+        assert 'Invalid format for meta data <class \'list\'>, must be dict' in str(err.value)
+
+    def test_vnd_meta_list(self, vnd_list, entity_ref_1):
+        entity_ref_1.meta = {
+            'key': 'value',
+            'other_key': 'other_value'
+        }
+        response = self.build_response(vnd_list)
+        AssertionHelper.HTTP_200(response, entity_refs=entity_ref_1, is_list=True)
+
+    def test_vnd_list_meta_mismatch(self, vnd_list, entity_ref_1):
+        response = self.build_response(vnd_list)
+        entity_ref_1.meta = {
+            'key': 'different value'
+        }
+        with pytest.raises(AssertionError) as err:
+            AssertionHelper.HTTP_200(response, entity_refs=entity_ref_1, is_list=True)
+        assert f'Meta field `key` had value `value` not `different value` as expected.' in str(err.value)
+
+    def test_vnd_list_meta_invalid_key(self, vnd_list, entity_ref_1):
+        entity_ref_1.meta = {
+            'invalid_key': 'value'
+        }
+        response = self.build_response(vnd_list)
+        with pytest.raises(AssertionError) as err:
+            AssertionHelper.HTTP_200(response, entity_refs=entity_ref_1, is_list=True)
+        assert f'Meta field `invalid_key` not found' in str(err.value)
+
+    def test_vnd_list_no_meta(self, vnd_list, entity_ref_3):
+        entity_ref_3.meta = {
+            'key': 'value',
+            'other_key': 'other_value'
+        }
+        response = self.build_response(vnd_list)
+        with pytest.raises(AssertionError) as err:
+            AssertionHelper.HTTP_200(response, entity_refs=entity_ref_3, is_list=True)
+        assert 'Meta missing' in str(err.value)
+
+    def test_vnd_list_invalid_meta_format(self, vnd_list, entity_ref_1):
+        entity_ref_1.meta = [{
+            'invalid_key': 'value'
+        }]
+        response = self.build_response(vnd_list)
+        with pytest.raises(AssertionError) as err:
+            AssertionHelper.HTTP_200(response, entity_refs=entity_ref_1, is_list=True)
         assert 'Invalid format for meta data <class \'list\'>, must be dict' in str(err.value)

--- a/tests/test_json_asserter.py
+++ b/tests/test_json_asserter.py
@@ -105,6 +105,10 @@ def vnd_single():
                         }
                     ]
                 }
+            },
+            'meta': {
+                'key': 'value',
+                'other_key': 'other_value',
             }
         },
         'included': [
@@ -1080,3 +1084,58 @@ class TestAssertionHelper:
         with pytest.raises(AssertionError) as err:
             AssertionHelper.HTTP_200(response, count=1)
         assert f'Count is only checked when response is list' in str(err.value)
+
+    def test_vnd_meta(self, vnd_single):
+        response = self.build_response(vnd_single)
+        AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
+            resource=EXAMPLE_RESOURCE['type'],
+            meta={
+                'key': 'value',
+                'other_key': 'other_value'
+            },
+         ))
+
+    def test_vnd_meta_mismatch(self, vnd_single):
+        response = self.build_response(vnd_single)
+        with pytest.raises(AssertionError) as err:
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
+                resource=EXAMPLE_RESOURCE['type'],
+                meta={
+                    'key': 'different value'
+                },
+             ))
+        assert f'Meta field `key` had value `value` not `different value` as expected.' in str(err.value)
+
+    def test_vnd_meta_invalid_key(self, vnd_single):
+        response = self.build_response(vnd_single)
+        with pytest.raises(AssertionError) as err:
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
+                resource=EXAMPLE_RESOURCE['type'],
+                meta={
+                    'invalid_key': 'value'
+                },
+             ))
+        assert f'Meta field `invalid_key` not found' in str(err.value)
+
+    def test_vnd_no_meta(self, vnd_single):
+        vnd_single['data'].pop('meta')
+        response = self.build_response(vnd_single)
+        with pytest.raises(AssertionError) as err:
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
+                resource=EXAMPLE_RESOURCE['type'],
+                meta={
+                    'key': 'value'
+                },
+             ))
+        assert 'Meta missing' in str(err.value)
+
+    def test_vnd_invalid_meta_format(self, vnd_single):
+        response = self.build_response(vnd_single)
+        with pytest.raises(AssertionError) as err:
+            AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
+                resource=EXAMPLE_RESOURCE['type'],
+                meta=[{
+                    'key': 'value'
+                }],
+             ))
+        assert 'Invalid format for meta data <class \'list\'>, must be dict' in str(err.value)


### PR DESCRIPTION
This branch adds the meta field to the entity ref and testing when vnd=True. This tests the meta on the individual objects, not the meta of the response in a list. It does not test against the meta provided in a normal list view that contains pagination data.