### PR TITLE
Add optional parameter to is_internal_call check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shipchain-common"
-version = "1.0.24"
+version = "1.0.25"
 description = "A PyPI package containing shared code for ShipChain's Python/Django projects."
 
 license = "Apache-2.0"

--- a/src/shipchain_common/authentication.py
+++ b/src/shipchain_common/authentication.py
@@ -48,7 +48,7 @@ def is_internal_call(request, service_name=None):
                    and request.META['X_SSL_CLIENT_VERIFY'] == 'SUCCESS')
     if service_name and is_internal:
         certificate_cn = parse_dn(request.META['X_SSL_CLIENT_DN'])['CN']
-        is_internal = is_internal and certificate_cn == f'{service_name}.{settings.ENVIRONMENT.lower()}-internal'
+        is_internal = certificate_cn == f'{service_name}.{settings.ENVIRONMENT.lower()}-internal'
     return is_internal
 
 

--- a/src/shipchain_common/authentication.py
+++ b/src/shipchain_common/authentication.py
@@ -43,19 +43,20 @@ def get_jwt_from_request(request):
     return None
 
 
-def is_internal_call(request):
-    return ('X_NGINX_SOURCE' in request.META and request.META['X_NGINX_SOURCE'] == 'internal'
-            and request.META['X_SSL_CLIENT_VERIFY'] == 'SUCCESS')
+def is_internal_call(request, service_name=None):
+    is_internal = ('X_NGINX_SOURCE' in request.META and request.META['X_NGINX_SOURCE'] == 'internal'
+                   and request.META['X_SSL_CLIENT_VERIFY'] == 'SUCCESS')
+    if service_name and is_internal:
+        certificate_cn = parse_dn(request.META['X_SSL_CLIENT_DN'])['CN']
+        is_internal = is_internal and certificate_cn == f'{service_name}.{settings.ENVIRONMENT.lower()}-internal'
+    return is_internal
 
 
 class InternalRequest(BasePermission):
     def has_permission(self, request, view):
         if settings.ENVIRONMENT in ('LOCAL', 'INT'):
             return True
-        if is_internal_call(request):
-            certificate_cn = parse_dn(request.META['X_SSL_CLIENT_DN'])['CN']
-            return certificate_cn == f'{self.SERVICE_NAME}.{settings.ENVIRONMENT.lower()}-internal'
-        return False
+        return is_internal_call(request, self.SERVICE_NAME)
 
 
 class EngineRequest(InternalRequest):


### PR DESCRIPTION
This feature adds an optional `service_name` parameter to the `is_internal_call` check. When included, it ensures that the internal call made is of the service name requested.