### PR TITLE
Full EntityRef UUID support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shipchain-common"
-version = "1.0.27"
+version = "1.0.28"
 description = "A PyPI package containing shared code for ShipChain's Python/Django projects."
 
 license = "Apache-2.0"

--- a/src/shipchain_common/test_utils/json_asserter.py
+++ b/src/shipchain_common/test_utils/json_asserter.py
@@ -28,6 +28,10 @@ class EntityReferenceClass:
         self.relationships = relationships
         self.meta = meta
 
+        if self.pk is not None:
+            # entity_ref.pk can be a CharField or a UUIDField. Force to string for easier comparisons.
+            self.pk = str(self.pk)
+
     def __str__(self):
         return f'Type: {self.resource}; ID: {self.pk}; ' \
                f'attributes: {self.attributes}; relationships: {self.relationships}'
@@ -201,8 +205,7 @@ def _vnd_assertions(response_data, entity_ref):
         assert response_data['type'] == entity_ref.resource, f'Invalid Resource Type in {response_data}'
 
     if entity_ref.pk:
-        # entity_ref.pk can be a CharField or a UUIDField. Force string comparison for ease of use with UUIDField.
-        assert response_data['id'] == str(entity_ref.pk), f'Invalid ID in {response_data}'
+        assert response_data['id'] == entity_ref.pk, f'Invalid ID in {response_data}'
 
     if entity_ref.attributes:
         _vnd_assert_attributes(response_data, entity_ref.attributes)

--- a/tests/test_json_asserter.py
+++ b/tests/test_json_asserter.py
@@ -1,9 +1,8 @@
-from unittest.mock import Mock
-import uuid
-
 import pytest
+import uuid
 from rest_framework import status
 from shipchain_common.test_utils import AssertionHelper
+from unittest.mock import Mock
 
 EXAMPLE_PLAIN = {
     'id': '07b374c3-ed9b-4811-901a-d0c5d746f16a',
@@ -738,10 +737,21 @@ class TestAssertionHelper:
 
     def test_vnd_entity_uuid_pk(self, vnd_single):
         response = self.build_response(vnd_single)
-        AssertionHelper.HTTP_200(response, entity_refs=AssertionHelper.EntityRef(
-            resource=EXAMPLE_RESOURCE['type'],
-            pk=uuid.UUID(EXAMPLE_RESOURCE['id'])
-        ))
+        AssertionHelper.HTTP_200(
+            response,
+            entity_refs=AssertionHelper.EntityRef(
+                resource=EXAMPLE_RESOURCE['type'],
+                pk=uuid.UUID(EXAMPLE_RESOURCE['id']),
+                attributes=EXAMPLE_RESOURCE['attributes'],
+                relationships={'owner': AssertionHelper.EntityRef(
+                    resource=EXAMPLE_USER['type'],
+                    pk=uuid.UUID(EXAMPLE_USER['id']),
+                )}
+            ),
+            included=AssertionHelper.EntityRef(
+                resource=EXAMPLE_RESOURCE_2['type'],
+                pk=uuid.UUID(EXAMPLE_RESOURCE_2['id']),
+            ))
 
     def test_vnd_entity_full_match(self, vnd_single):
         response = self.build_response(vnd_single)


### PR DESCRIPTION
Any models that have a `UUIDField` primary key will fail the assertion with a string uuid.  When instantiating `EntityRef` instances, forcing string representation of the `pk` field will allow for transparent assertions.