### PR TITLE
Ensure context is passed through when calling `get_serializer`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shipchain-common"
-version = "1.0.29"
+version = "1.0.30"
 description = "A PyPI package containing shared code for ShipChain's Python/Django projects."
 
 license = "Apache-2.0"

--- a/src/shipchain_common/viewsets.py
+++ b/src/shipchain_common/viewsets.py
@@ -232,7 +232,9 @@ class ConfigurableGenericViewSet(GenericViewSet):
         """
         serialization_type = kwargs.pop('serialization_type', mixins.SerializationType.REQUEST)
         serializer_class = self.get_serializer_class(serialization_type)
-        kwargs['context'] = self.get_serializer_context()
+        if 'context' not in kwargs:
+            kwargs['context'] = {}
+        kwargs['context'].update(self.get_serializer_context())
         return serializer_class(*args, **kwargs)
 
     # pylint: disable=arguments-differ

--- a/src/shipchain_common/viewsets.py
+++ b/src/shipchain_common/viewsets.py
@@ -232,9 +232,7 @@ class ConfigurableGenericViewSet(GenericViewSet):
         """
         serialization_type = kwargs.pop('serialization_type', mixins.SerializationType.REQUEST)
         serializer_class = self.get_serializer_class(serialization_type)
-        if 'context' not in kwargs:
-            kwargs['context'] = {}
-        kwargs['context'].update(self.get_serializer_context())
+        kwargs.setdefault('context', self.get_serializer_context())
         return serializer_class(*args, **kwargs)
 
     # pylint: disable=arguments-differ


### PR DESCRIPTION
When calling `get_serializer` on `ConfigurableGenericViewSet`, ensure that `context` is passed through, and not overwritten by the `get_serializer_context` in the default `get_serializer`.